### PR TITLE
Allow arguments that respond to to_hash, instead of only Hash instances

### DIFF
--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -57,7 +57,7 @@ module Mutations
     def initialize(*args)
       @raw_inputs = args.inject({}.with_indifferent_access) do |h, arg|
         raise ArgumentError.new("All arguments must be hashes or respond to to_hash") unless arg.respond_to?(:to_hash)
-        h.merge!(arg.to_hash)
+        h.merge!(arg)
       end
 
       # Do field-level validation / filtering:

--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -56,8 +56,8 @@ module Mutations
     # Instance methods
     def initialize(*args)
       @raw_inputs = args.inject({}.with_indifferent_access) do |h, arg|
-        raise ArgumentError.new("All arguments must be hashes") unless arg.is_a?(Hash)
-        h.merge!(arg)
+        raise ArgumentError.new("All arguments must be hashes or respond to to_h") unless arg.respond_to?(:to_h)
+        h.merge!(arg.to_h)
       end
 
       # Do field-level validation / filtering:

--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -56,8 +56,8 @@ module Mutations
     # Instance methods
     def initialize(*args)
       @raw_inputs = args.inject({}.with_indifferent_access) do |h, arg|
-        raise ArgumentError.new("All arguments must be hashes or respond to to_h") unless arg.respond_to?(:to_h)
-        h.merge!(arg.to_h)
+        raise ArgumentError.new("All arguments must be hashes or respond to to_hash") unless arg.respond_to?(:to_hash)
+        h.merge!(arg.to_hash)
       end
 
       # Do field-level validation / filtering:

--- a/lib/mutations/command.rb
+++ b/lib/mutations/command.rb
@@ -56,7 +56,7 @@ module Mutations
     # Instance methods
     def initialize(*args)
       @raw_inputs = args.inject({}.with_indifferent_access) do |h, arg|
-        raise ArgumentError.new("All arguments must be hashes or respond to to_hash") unless arg.respond_to?(:to_hash)
+        raise ArgumentError.new("All arguments must be hashes") unless arg.respond_to?(:to_hash)
         h.merge!(arg)
       end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -87,7 +87,7 @@ describe "Command" do
       assert_equal ({:name => "John", :email => "bob@jones.com", :amount => 5}).stringify_keys, outcome.result
     end
 
-    it "shouldn't accept non-hashes" do
+    it "shouldn't accept objects that are not hashes or directly mappable to hashes" do
       assert_raises ArgumentError do
         SimpleCommand.run(nil)
       end
@@ -99,6 +99,19 @@ describe "Command" do
       assert_raises ArgumentError do
         SimpleCommand.run({:name => "John"}, 1)
       end
+    end
+
+    it 'should accept objects that are conceptually hashes' do
+      class CustomPersonHash
+        def to_hash
+          { name: 'John', email: 'john@example.com' }
+        end
+      end
+
+      outcome = SimpleCommand.run(CustomPersonHash.new)
+
+      assert outcome.success?
+      assert_equal ({ name: "John", email: "john@example.com" }).stringify_keys, outcome.result
     end
 
     it "should accept nothing at all" do


### PR DESCRIPTION
This is antoniobg's work from this PR: https://github.com/cypriss/mutations/pull/126